### PR TITLE
fix: legacy_cycles build + archive naming + build-test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           - variant: legacy_eevee
             blender: "2.80"
           - variant: eevee
-            blender: "2.93"
+            blender: "2.93.18"
           - variant: cyclesx
             blender: "3.6"
           - variant: eevee_next
@@ -103,6 +103,10 @@ jobs:
 
       - name: Generate scripts
         run: uv run python ${{ matrix.variant }}/generate_scripts.py
+
+      - name: Install system deps (2.79)
+        if: matrix.blender == '2.79'
+        run: sudo apt-get update && sudo apt-get install -y libglu1-mesa
 
       - name: Build ${{ matrix.variant }}
         run: ${{ steps.blender.outputs.path }} -b --python ${{ matrix.variant }}/main.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,53 @@ jobs:
           pytest -p pytest-blender tests/test_plane_materials_bpy.py tests/test_build_utils_bpy.py tests/test_scenes_bpy.py -v
         env:
           BLENDER_EXECUTABLE: ${{ steps.blender.outputs.path }}
+
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: legacy
+            blender: "2.79"
+          - variant: legacy_cycles
+            blender: "2.79"
+          - variant: legacy_eevee
+            blender: "2.80"
+          - variant: eevee
+            blender: "2.93"
+          - variant: cyclesx
+            blender: "3.6"
+          - variant: eevee_next
+            blender: "4.3"
+          - variant: hi_five
+            blender: "5.1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Cache Blender
+        uses: actions/cache@v4
+        with:
+          path: blender-*
+          key: build-blender-${{ matrix.blender }}
+
+      - name: Download Blender
+        id: blender
+        run: |
+          pip install blender-downloader 2>/dev/null
+          echo "path=$(blender-downloader ${{ matrix.blender }} --extract --remove-compressed --print-blender-executable --quiet)" >> $GITHUB_OUTPUT
+
+      - name: Generate scripts
+        run: uv run python ${{ matrix.variant }}/generate_scripts.py
+
+      - name: Build ${{ matrix.variant }}
+        run: ${{ steps.blender.outputs.path }} -b --python ${{ matrix.variant }}/main.py
+
+      - name: Verify output
+        run: ls release/${{ matrix.variant }}/*.blend

--- a/build.sh
+++ b/build.sh
@@ -192,7 +192,7 @@ fi
 
 # --- 10) Archive generated .blend files ---
 for f in "release/$engine"/*.blend; do
-    base=${f%%.*}
+    base=${f%.*}
     zip_file="${base}.zip"
     sevenz_file="${base}.7z"
 

--- a/legacy_cycles/plane_materials.py
+++ b/legacy_cycles/plane_materials.py
@@ -127,7 +127,6 @@ def Plane_Shadow(suffix):
   shadow_mat.use_nodes = True
   _remove_default_shader(shadow_mat)
   output_node01 = shadow_mat.node_tree.nodes["Material Output"]
-  output_node01.target = 'CYCLES'
   lightpath_node = shadow_mat.node_tree.nodes.new('ShaderNodeLightPath')
   diffuse_node01 = shadow_mat.node_tree.nodes.new('ShaderNodeBsdfDiffuse')
   diffuse_node01.inputs[0].default_value = (0.090655, 0.090655, 0.090655, 1)
@@ -144,51 +143,5 @@ def Plane_Shadow(suffix):
   shadow_mat.node_tree.links.new(diffuse_node02.outputs[0], mixshader_node01.inputs[2])
   shadow_mat.node_tree.links.new(mixshader_node01.outputs[0], mixshader_node02.inputs[2])
   shadow_mat.node_tree.links.new(mixshader_node02.outputs[0], output_node01.inputs[0])
-  output_node02 = shadow_mat.node_tree.nodes.new('ShaderNodeOutputMaterial')
-  output_node02.target = 'EEVEE'
-  tex_coord_node = shadow_mat.node_tree.nodes.new('ShaderNodeTexCoord')
-  value_node = shadow_mat.node_tree.nodes.new('ShaderNodeValue')
-  value_node.outputs[0].default_value = 0.01
-  multiply_node = shadow_mat.node_tree.nodes.new('ShaderNodeMixRGB')
-  multiply_node.blend_type = 'MULTIPLY'
-  multiply_node.inputs[0].default_value = 1
-  gradient_node = shadow_mat.node_tree.nodes.new('ShaderNodeTexGradient')
-  gradient_node.gradient_type = 'QUADRATIC_SPHERE'
-  gamma01_node = shadow_mat.node_tree.nodes.new('ShaderNodeGamma')
-  gamma01_node.inputs[1].default_value = 0.001
-  diffuse_node03 = shadow_mat.node_tree.nodes.new('ShaderNodeBsdfDiffuse')
-  diffuse_node03.inputs[0].default_value = (1, 1, 1, 1)
-  diffuse_node03.inputs[1].default_value = 0
-  to_rgb_node = shadow_mat.node_tree.nodes.new('ShaderNodeShaderToRGB')
-  rgb_to_bw_node = shadow_mat.node_tree.nodes.new('ShaderNodeRGBToBW')
-  gamma02_node = shadow_mat.node_tree.nodes.new('ShaderNodeGamma')
-  gamma02_node.inputs[1].default_value = 3.9
-  colorramp_node = shadow_mat.node_tree.nodes.new('ShaderNodeValToRGB')
-  colorramp_node.color_ramp.elements[1].position = 0.132
-  mix_node = shadow_mat.node_tree.nodes.new('ShaderNodeMixRGB')
-  mix_node.inputs[1].default_value = (0.431555, 0.431555, 0.431555, 1)
-  greater_node = shadow_mat.node_tree.nodes.new('ShaderNodeMath')
-  greater_node.operation = 'GREATER_THAN'
-  greater_node.inputs[1].default_value = 0.1
-  diffuse_node04 = shadow_mat.node_tree.nodes.new('ShaderNodeBsdfDiffuse')
-  diffuse_node04.inputs[0].default_value = (0, 0, 0, 1)
-  diffuse_node04.inputs[1].default_value = 0
-  transparent_node02 = shadow_mat.node_tree.nodes.new('ShaderNodeBsdfTransparent')
-  mixshader_node03 = shadow_mat.node_tree.nodes.new('ShaderNodeMixShader')
-  shadow_mat.node_tree.links.new(tex_coord_node.outputs[3], multiply_node.inputs[1])
-  shadow_mat.node_tree.links.new(value_node.outputs[0], multiply_node.inputs[2])
-  shadow_mat.node_tree.links.new(multiply_node.outputs[0], gradient_node.inputs[0])
-  shadow_mat.node_tree.links.new(gradient_node.outputs[0], gamma01_node.inputs[0])
-  shadow_mat.node_tree.links.new(gamma01_node.outputs[0], mix_node.inputs[0])
-  shadow_mat.node_tree.links.new(diffuse_node03.outputs[0], to_rgb_node.inputs[0])
-  shadow_mat.node_tree.links.new(to_rgb_node.outputs[0], rgb_to_bw_node.inputs[0])
-  shadow_mat.node_tree.links.new(rgb_to_bw_node.outputs[0], gamma02_node.inputs[0])
-  shadow_mat.node_tree.links.new(gamma02_node.outputs[0], colorramp_node.inputs[0])
-  shadow_mat.node_tree.links.new(colorramp_node.outputs[0], mix_node.inputs[2])
-  shadow_mat.node_tree.links.new(mix_node.outputs[0], greater_node.inputs[0])
-  shadow_mat.node_tree.links.new(greater_node.outputs[0], mixshader_node03.inputs[0])
-  shadow_mat.node_tree.links.new(diffuse_node04.outputs[0], mixshader_node03.inputs[1])
-  shadow_mat.node_tree.links.new(transparent_node02.outputs[0], mixshader_node03.inputs[2])
-  shadow_mat.node_tree.links.new(mixshader_node03.outputs[0], output_node02.inputs[0])
 
   return shadow_mat

--- a/legacy_cycles/world_materials.py
+++ b/legacy_cycles/world_materials.py
@@ -5,6 +5,22 @@ current_path = os.path.dirname(os.path.realpath(__file__))
 
 BASE_COLOR = (0, 0, 0)
 
+def _set_mapping(node, location=None, rotation=None, scale=None):
+  if len(node.inputs) > 2:
+    if location is not None:
+      node.inputs[1].default_value = location
+    if rotation is not None:
+      node.inputs[2].default_value = rotation
+    if scale is not None:
+      node.inputs[3].default_value = scale
+  else:
+    if location is not None:
+      node.translation = location
+    if rotation is not None:
+      node.rotation = rotation
+    if scale is not None:
+      node.scale = scale
+
 def RA2_World(world_texture_path, world_texture_name, suffix):
   tex_dir = os.path.join(os.path.dirname(current_path), world_texture_path)
   
@@ -17,9 +33,9 @@ def RA2_World(world_texture_path, world_texture_name, suffix):
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node01.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node01, rotation=(0, 0, -1.22173))
   mapping_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node02.inputs[1].default_value = (0, 0, 0.3)
+  _set_mapping(mapping_node02, location=(0, 0, 0.3))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:
@@ -84,9 +100,9 @@ def RA1_World(world_texture_path, world_texture_name, suffix):
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node01.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node01, rotation=(0, 0, -1.22173))
   mapping_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node02.inputs[1].default_value = (0, 0, 0.3)
+  _set_mapping(mapping_node02, location=(0, 0, 0.3))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:
@@ -146,17 +162,12 @@ def RW_World(world_texture_path, world_texture_name, suffix):
   bpy.context.scene.world = world
   bpy.context.scene.world.horizon_color = (0.0998987, 0.0684781, 0.0318961)
   bpy.context.scene.world.use_nodes = True
-  output_node01 = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
-  if hasattr(output_node01, 'target'):
-    output_node01.target = 'EEVEE'
-  world.node_tree.links.remove(output_node01.inputs[0].links[0])
-  output_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeOutputWorld")
-  if hasattr(output_node02, 'target'):
-    output_node02.target = 'CYCLES'
+  output_node = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
+  world.node_tree.links.remove(output_node.inputs[0].links[0])
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node, rotation=(0, 0, -1.22173))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:
@@ -167,35 +178,24 @@ def RW_World(world_texture_path, world_texture_name, suffix):
   huesat_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeHueSaturation")
   huesat_node01.inputs[1].default_value = 0.5
   huesat_node01.inputs[2].default_value = 0.35
-  huesat_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeHueSaturation")
-  huesat_node02.inputs[1].default_value = 0.5
-  huesat_node02.inputs[2].default_value = 0.25
   background_node01 = bpy.data.worlds["World."+suffix].node_tree.nodes["Background"]
   background_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03.inputs[0].default_value = (0, 0, 1, 1)
-  background_node04 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   mixshader_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
-  mixshader_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
   mixshader_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
 
-  world.node_tree.links.new(mixshader_node01.outputs[0], output_node01.inputs[0])
-  world.node_tree.links.new(mixshader_node02.outputs[0], output_node02.inputs[0])
+  world.node_tree.links.new(mixshader_node01.outputs[0], output_node.inputs[0])
   world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node01.inputs[2])
-  world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node02.inputs[2])
   world.node_tree.links.new(lightpath_node.outputs[0], mixshader_node03.inputs[0])
   world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node01.inputs[0])
-  world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node02.inputs[0])
   world.node_tree.links.new(background_node01.outputs[0], mixshader_node01.inputs[1])
   world.node_tree.links.new(background_node02.outputs[0], mixshader_node03.inputs[1])
   world.node_tree.links.new(background_node03.outputs[0], mixshader_node03.inputs[2])
-  world.node_tree.links.new(background_node04.outputs[0], mixshader_node02.inputs[1])
   world.node_tree.links.new(huesat_node01.outputs[0], background_node01.inputs[0])
-  world.node_tree.links.new(huesat_node02.outputs[0], background_node04.inputs[0])
   world.node_tree.links.new(tex_env_node.outputs[0], background_node02.inputs[0])
 
   world.node_tree.links.new(tex_env_node.outputs[0], huesat_node01.inputs[0])
-  world.node_tree.links.new(tex_env_node.outputs[0], huesat_node02.inputs[0])
   world.node_tree.links.new(mapping_node.outputs[0], tex_env_node.inputs[0])
   world.node_tree.links.new(tex_coord_node.outputs[0], mapping_node.inputs[0])
 
@@ -208,17 +208,12 @@ def TS_World(world_texture_path, world_texture_name, suffix):
   bpy.context.scene.world = world
   bpy.context.scene.world.horizon_color = (0.191202, 0.191202, 0.191202)
   bpy.context.scene.world.use_nodes = True
-  output_node01 = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
-  if hasattr(output_node01, 'target'):
-    output_node01.target = 'EEVEE'
-  world.node_tree.links.remove(output_node01.inputs[0].links[0])
-  output_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeOutputWorld")
-  if hasattr(output_node02, 'target'):
-    output_node02.target = 'CYCLES'
+  output_node = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
+  world.node_tree.links.remove(output_node.inputs[0].links[0])
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node, rotation=(0, 0, -1.22173))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:
@@ -236,28 +231,20 @@ def TS_World(world_texture_path, world_texture_name, suffix):
   background_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03.inputs[0].default_value = (0, 0, 1, 1)
-  background_node04 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   mixshader_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
   mixshader_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
-  mixshader_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
 
-  world.node_tree.links.new(mixshader_node01.outputs[0], output_node01.inputs[0])
-  world.node_tree.links.new(mixshader_node02.outputs[0], output_node02.inputs[0])
-  world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node01.inputs[2])
-  world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node02.inputs[2])
-  world.node_tree.links.new(lightpath_node.outputs[0], mixshader_node03.inputs[0])
+  world.node_tree.links.new(mixshader_node01.outputs[0], output_node.inputs[0])
+  world.node_tree.links.new(mixshader_node02.outputs[0], mixshader_node01.inputs[2])
+  world.node_tree.links.new(lightpath_node.outputs[0], mixshader_node02.inputs[0])
   world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node01.inputs[0])
-  world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node02.inputs[0])
   world.node_tree.links.new(background_node01.outputs[0], mixshader_node01.inputs[1])
-  world.node_tree.links.new(background_node02.outputs[0], mixshader_node03.inputs[1])
-  world.node_tree.links.new(background_node03.outputs[0], mixshader_node03.inputs[2])
-  world.node_tree.links.new(background_node04.outputs[0], mixshader_node02.inputs[1])
+  world.node_tree.links.new(background_node02.outputs[0], mixshader_node02.inputs[1])
+  world.node_tree.links.new(background_node03.outputs[0], mixshader_node02.inputs[2])
   world.node_tree.links.new(huesat_node01.outputs[0], background_node01.inputs[0])
-  world.node_tree.links.new(huesat_node02.outputs[0], background_node04.inputs[0])
   world.node_tree.links.new(tex_env_node.outputs[0], background_node02.inputs[0])
 
   world.node_tree.links.new(tex_env_node.outputs[0], huesat_node01.inputs[0])
-  world.node_tree.links.new(tex_env_node.outputs[0], huesat_node02.inputs[0])
   world.node_tree.links.new(mapping_node.outputs[0], tex_env_node.inputs[0])
   world.node_tree.links.new(tex_coord_node.outputs[0], mapping_node.inputs[0])
 
@@ -270,17 +257,12 @@ def D2K_World(world_texture_path, world_texture_name, suffix):
   bpy.context.scene.world = world
   bpy.context.scene.world.horizon_color = BASE_COLOR
   bpy.context.scene.world.use_nodes = True
-  output_node01 = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
-  if hasattr(output_node01, 'target'):
-    output_node01.target = 'EEVEE'
-  world.node_tree.links.remove(output_node01.inputs[0].links[0])
-  output_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeOutputWorld")
-  if hasattr(output_node02, 'target'):
-    output_node02.target = 'CYCLES'
+  output_node = bpy.data.worlds["World."+suffix].node_tree.nodes["World Output"]
+  world.node_tree.links.remove(output_node.inputs[0].links[0])
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node, rotation=(0, 0, -1.22173))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:
@@ -298,28 +280,20 @@ def D2K_World(world_texture_path, world_texture_name, suffix):
   background_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   background_node03.inputs[0].default_value = (0, 0, 1, 1)
-  background_node04 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeBackground")
   mixshader_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
   mixshader_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
-  mixshader_node03 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMixShader")
 
-  world.node_tree.links.new(mixshader_node01.outputs[0], output_node01.inputs[0])
-  world.node_tree.links.new(mixshader_node02.outputs[0], output_node02.inputs[0])
-  world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node01.inputs[2])
-  world.node_tree.links.new(mixshader_node03.outputs[0], mixshader_node02.inputs[2])
-  world.node_tree.links.new(lightpath_node.outputs[0], mixshader_node03.inputs[0])
+  world.node_tree.links.new(mixshader_node01.outputs[0], output_node.inputs[0])
+  world.node_tree.links.new(mixshader_node02.outputs[0], mixshader_node01.inputs[2])
+  world.node_tree.links.new(lightpath_node.outputs[0], mixshader_node02.inputs[0])
   world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node01.inputs[0])
-  world.node_tree.links.new(lightpath_node.outputs[3], mixshader_node02.inputs[0])
   world.node_tree.links.new(background_node01.outputs[0], mixshader_node01.inputs[1])
-  world.node_tree.links.new(background_node02.outputs[0], mixshader_node03.inputs[1])
-  world.node_tree.links.new(background_node03.outputs[0], mixshader_node03.inputs[2])
-  world.node_tree.links.new(background_node04.outputs[0], mixshader_node02.inputs[1])
+  world.node_tree.links.new(background_node02.outputs[0], mixshader_node02.inputs[1])
+  world.node_tree.links.new(background_node03.outputs[0], mixshader_node02.inputs[2])
   world.node_tree.links.new(huesat_node01.outputs[0], background_node01.inputs[0])
-  world.node_tree.links.new(huesat_node02.outputs[0], background_node04.inputs[0])
   world.node_tree.links.new(tex_env_node.outputs[0], background_node02.inputs[0])
 
   world.node_tree.links.new(tex_env_node.outputs[0], huesat_node01.inputs[0])
-  world.node_tree.links.new(tex_env_node.outputs[0], huesat_node02.inputs[0])
   world.node_tree.links.new(mapping_node.outputs[0], tex_env_node.inputs[0])
   world.node_tree.links.new(tex_coord_node.outputs[0], mapping_node.inputs[0])
 
@@ -337,9 +311,9 @@ def RM_World(world_texture_path, world_texture_name, suffix):
   tex_coord_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeTexCoord")
   lightpath_node = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeLightPath")
   mapping_node01 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node01.inputs[2].default_value = (0, 0, -1.22173)
+  _set_mapping(mapping_node01, rotation=(0, 0, -1.22173))
   mapping_node02 = bpy.context.scene.world.node_tree.nodes.new("ShaderNodeMapping")
-  mapping_node02.inputs[1].default_value = (0, 0, 0.3)
+  _set_mapping(mapping_node02, location=(0, 0, 0.3))
   # Recycle the same world texture file instead of loading new one again and again
   data_image = bpy.data.images.get(world_texture_name)
   if not data_image:

--- a/shared/plane_materials.py
+++ b/shared/plane_materials.py
@@ -159,30 +159,31 @@ def Plane_Shadow(suffix):
   mat.node_tree.links.new(mix01.outputs[0], mix02.inputs[2])
   mat.node_tree.links.new(mix02.outputs[0], output01.inputs[0])
 
-  # Eevee output (2.80+ only)
-  try:
-    output02 = mat.node_tree.nodes.new("ShaderNodeOutputMaterial")
-    if hasattr(output02, "target"):
-      output02.target = "EEVEE"
-    mix03 = mat.node_tree.nodes.new("ShaderNodeMixShader")
-    principled = mat.node_tree.nodes.new("ShaderNodeBsdfPrincipled")
-    principled.inputs[0].default_value = (0.371235, 0.371238, 0.371238, 0)
+  # Eevee output (2.80+ only) — ShaderNodeShaderToRGB doesn't exist before 2.80
+  if bpy.app.version >= (2, 80, 0):
     try:
-      principled.inputs[2].default_value = 0.0
-    except (TypeError, ValueError):
-      principled.inputs[2].default_value = (0, 0, 0)
-    transparent02 = mat.node_tree.nodes.new("ShaderNodeBsdfTransparent")
-    shader_to_rgb = mat.node_tree.nodes.new("ShaderNodeShaderToRGB")
-    diffuse03 = mat.node_tree.nodes.new("ShaderNodeBsdfDiffuse")
-    diffuse03.inputs[0].default_value = (0, 0, 0, 1)
-    diffuse03.inputs[1].default_value = 0
+      output02 = mat.node_tree.nodes.new("ShaderNodeOutputMaterial")
+      if hasattr(output02, "target"):
+        output02.target = "EEVEE"
+      mix03 = mat.node_tree.nodes.new("ShaderNodeMixShader")
+      principled = mat.node_tree.nodes.new("ShaderNodeBsdfPrincipled")
+      principled.inputs[0].default_value = (0.371235, 0.371238, 0.371238, 0)
+      try:
+        principled.inputs[2].default_value = 0.0
+      except (TypeError, ValueError):
+        principled.inputs[2].default_value = (0, 0, 0)
+      transparent02 = mat.node_tree.nodes.new("ShaderNodeBsdfTransparent")
+      shader_to_rgb = mat.node_tree.nodes.new("ShaderNodeShaderToRGB")
+      diffuse03 = mat.node_tree.nodes.new("ShaderNodeBsdfDiffuse")
+      diffuse03.inputs[0].default_value = (0, 0, 0, 1)
+      diffuse03.inputs[1].default_value = 0
 
-    mat.node_tree.links.new(principled.outputs[0], shader_to_rgb.inputs[0])
-    mat.node_tree.links.new(shader_to_rgb.outputs[0], mix03.inputs[0])
-    mat.node_tree.links.new(diffuse03.outputs[0], mix03.inputs[1])
-    mat.node_tree.links.new(transparent02.outputs[0], mix03.inputs[2])
-    mat.node_tree.links.new(mix03.outputs[0], output02.inputs[0])
-  except (RuntimeError, KeyError):
-    pass
+      mat.node_tree.links.new(principled.outputs[0], shader_to_rgb.inputs[0])
+      mat.node_tree.links.new(shader_to_rgb.outputs[0], mix03.inputs[0])
+      mat.node_tree.links.new(diffuse03.outputs[0], mix03.inputs[1])
+      mat.node_tree.links.new(transparent02.outputs[0], mix03.inputs[2])
+      mat.node_tree.links.new(mix03.outputs[0], output02.inputs[0])
+    except (RuntimeError, KeyError):
+      pass
 
   return mat


### PR DESCRIPTION
## Changes

### 1. Mapping node IndexError in legacy_cycles
Copied `_set_mapping()` helper from `eevee/world_materials.py` into `legacy_cycles/world_materials.py` and replaced all 10 direct `inputs[]` accesses. Blender 2.79 Mapping node has only 1 input (Vector), not 4 like 2.80+.

### 2. Archive naming fix
Changed `build.sh:195` from `${f%%.*}` to `${f%.*}`. Archives now retain full version/build/date info instead of stripping everything after the first dot.

### 3. EEVEE removal from legacy_cycles
Blender 2.79 predated EEVEE entirely. Removed:
- EEVEE output section (ShaderToRGB) from `legacy_cycles/plane_materials.py`
- Dual-output pattern from `legacy_cycles/world_materials.py` (RW/TS/D2K)
- Added version check in `shared/plane_materials.py` to skip EEVEE output on Blender <2.80

### 4. Build-test CI job
Added `build-test` job to `.github/workflows/test.yml` — validates generate + Blender headless for all 7 variants in parallel:
- legacy (2.79), legacy_cycles (2.79), legacy_eevee (2.80)
- eevee (2.93), cyclesx (3.6), eevee_next (4.3), hi_five (5.1)

Closes #8
Closes #12